### PR TITLE
fix: unicode escape sequence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simple-yenc",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "simple-yenc",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-yenc",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Minimalist yEnc and dynEncode encoder and decoder library for browser and NodeJS",
   "main": "src/simple-yenc.js",
   "scripts": {

--- a/src/simple-yenc.js
+++ b/src/simple-yenc.js
@@ -136,6 +136,7 @@ const dynamicEncode = (byteArray, stringWrapper = '"') => {
       byte1 === 61 || // =
       byte1 === 13 || // CR
       byte1 === 96 || // `
+      (byte1 === 92 && (byte2 === 85 || byte2 === 117)) || // \u or \U
       (byte1 === 36 && byte2 === 123); // ${
 
   // search for the byte offset with the least amount of escape characters


### PR DESCRIPTION
## Fixes
* Escape `\` when followed by a `u` or `U` to avoid unicode escape characters