### PR TITLE
provide esm for tree-shaking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.dynamic.*
+dist

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Install via [NPM](https://www.npmjs.com/package/simple-yenc)
 const yenc = require("simple-yenc");
 
 // ES6 Import
-import yenc from "simple-yenc";
+import * as yenc from "simple-yenc";
 ```
 
 ### `encode()`

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "devDependencies": {
         "@types/jest": "^29.1.2",
         "jest": "^29.1.2",
-        "prettier": "^2.7.1"
+        "prettier": "^2.7.1",
+        "rollup": "^3.12.1"
       },
       "funding": {
         "type": "individual",
@@ -3030,6 +3031,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/rollup": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.12.1.tgz",
+      "integrity": "sha512-t9elERrz2i4UU9z7AwISj3CQcXP39cWxgRWLdf4Tm6aKm1eYrqHIgjzXBgb67GNY1sZckTFFi0oMozh3/S++Ig==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -5756,6 +5773,15 @@
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz",
       "integrity": "sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==",
       "dev": true
+    },
+    "rollup": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.12.1.tgz",
+      "integrity": "sha512-t9elERrz2i4UU9z7AwISj3CQcXP39cWxgRWLdf4Tm6aKm1eYrqHIgjzXBgb67GNY1sZckTFFi0oMozh3/S++Ig==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.2"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,11 @@
   "name": "simple-yenc",
   "version": "0.2.3",
   "description": "Minimalist yEnc and dynEncode encoder and decoder library for browser and NodeJS",
-  "main": "src/simple-yenc.js",
+  "main": "dist/index.js",
+  "module": "dist/esm.js",
   "scripts": {
     "test": "jest --maxWorkers=100%",
+    "build": "rollup -c --bundleConfigAsCjs",
     "format": "prettier --write '**/*.js' --write 'package.json'"
   },
   "repository": {
@@ -32,6 +34,7 @@
   "devDependencies": {
     "@types/jest": "^29.1.2",
     "jest": "^29.1.2",
-    "prettier": "^2.7.1"
+    "prettier": "^2.7.1",
+    "rollup": "^3.12.1"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,13 @@
+export default {
+  input: "./src/simple-yenc.js",
+  output: [
+    {
+      file: "dist/esm.js",
+      format: "esm",
+    },
+    {
+      file: "dist/index.js",
+      format: "cjs",
+    },
+  ],
+};

--- a/src/simple-yenc.js
+++ b/src/simple-yenc.js
@@ -193,9 +193,4 @@ const stringify = (rawString) =>
     .replace(/[`]/g, "\\`")
     .replace(/\${/g, "\\${");
 
-module.exports = {
-  encode,
-  dynamicEncode,
-  decode,
-  stringify,
-};
+export { encode, dynamicEncode, decode, stringify };

--- a/test/simple-yenc.test.js
+++ b/test/simple-yenc.test.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const path = require("path");
 const { Worker } = require("worker_threads");
 
-const yenc = require("../src/simple-yenc");
+const yenc = require("..");
 
 const bytesPath = path.join(__dirname, "bytes.bin");
 const encodedBytesPath = path.join(__dirname, "bytes.yenc");


### PR DESCRIPTION
Hello

this library is supper small but still has space for improvement

i added an `esm` entry to decrease the size that is sent to the browser

[current size `1.09KB (gzip)`](https://bundlejs.com/?q=simple-yenc&treeshake=%5B%7B+decode+%7D%5D) vs [decode size `397B (gzip)`](https://bundlejs.com/?share=KYDwDg9gTgLgBAYwgOwM7wCbCVuBeOACnSgEtkBzASnwD44BvAKDkRXTgAsYBbAGwDCELAHkAbsChksqfHGTAA7nACyAQzCEqAbhZwA2ntYAaI3AAcAZgBsAFlOsTZ8wCYAjOYePbABhdfWVxd-ZxdLHwCLYPtQlwBWSIB2NwjQ30jLOJDHKNsATgzLTzMM8zdIitC3a0jXN0Ta4NScoPLYmqq2lvdsx0TLXsDbVwy4y0a45sdLSwKSsyLBuEtEjtYAXQA6ADNoAFE1BE5CQgBrYzgxGjx6bn4hUQkpUhlN1GAYM4urnSY9JDQ8AgAFcYGBQXIFMoAKrkGDmACCUjUAE9iDAyJRNnxgJQYJxfnocfBgKgEBpgBg5Ns1Hx3pEAEYomDAACSyCwIDkU1YTJZkQg22273gBFs-jgAHpJXAsDTgXx4Ci9sgEHBBcKPmZ0GpYKyMFyCD5dHpSNsiCRyBRsbiKPi4PQ3JY4AAyF1wS1Y1DAhmeiiECJwPLXPAEABEGBRyBVOGAYZozByAI4T1QpBQcjAuve7M%2BfrePr9hAKcDcbioF2qvxyZqIqfTyHwobgPgTZlYGpFmezbOQeYxVoLvoHlEIZcrlgrpes1ZyHpgupg%2BsNpcsuhyAF89Fv-uwgUKRQAlYCp4ByeLWOAAWnVB4%2BJtYuygRGJcFIch1eoN2jfcAAPPOmLWjieKcD%2BpAANQQW2OR8meBD5kcuoPMACKfKQhI1uahBwU2BDWG4rrugAhKS5JgJSMFzmRFJUgQGLAsA65zgCMDkIxzGsDuWFELh9DxHEVFJnuXC8Hw4iSNI8GifcwjABJzyvBQHw4cywCzjxhB3OJTxSTQuEENpClSXAEGli4iScXA3GOLWhA0RRGBCY4DmUtStLvFZvJqde%2BG2FZNkdqC4IwPocHspyUHrPg7ZwLhAGdh8RFxT59A%2BHAAD8KUsqZt6ajAx6nnAABc2VnjeiUwMxNlQB8wJQI2IJgqCQ66lAqIBhc4UcqAvwbtoQA)


